### PR TITLE
Remove unneded use of replace, causing json to fail loading the alert

### DIFF
--- a/selfdrive/controls/controlsd.py
+++ b/selfdrive/controls/controlsd.py
@@ -511,7 +511,7 @@ def controlsd_thread(sm=None, pm=None, can_sock=None):
 
   # FIXME: offroad alerts should not be created with negative severity
   connectivity_alert = params.get("Offroad_ConnectivityNeeded", encoding='utf8')
-  internet_needed = connectivity_alert is not None and json.loads(connectivity_alert.replace("'", "\""))["severity"] >= 0
+  internet_needed = connectivity_alert is not None and json.loads(connectivity_alert)["severity"] >= 0
 
   prof = Profiler(False)  # off by default
 


### PR DESCRIPTION
Choose one of the templates below:

# Fingerprint
This pull requests adds a fingerprint for <Make - Model - Year - Trim>.

This is an explorer link to a drive with the stock system enabled: ...

# Car support
This pull requests adds support for <Make - Model - Year - Trim>.

This is an explorer link to a drive with the stock system enabled: ...
This is an explorer link to a drive with openpilot system enabled: ...

# Feature
This pull requests adds feature X

## Description
Explain what the feature does

## Testing
Explain how the feature was tested. Either by the added unit tests, or what tests were performed while driving.
